### PR TITLE
Status badge now links to .pdf and not badge.svg

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,7 +15,7 @@ U kan de pdf [[https://www.sharelatex.com/github/repos/NorfairKing/ab-notities/b
 
 #+CAPTION: pdf build status
 #+NAME:   fig:buildstatus
-[[https://www.sharelatex.com/github/repos/NorfairKing/ab-notities/builds/latest/badge.svg]]
+[[https://www.sharelatex.com/github/repos/NorfairKing/ab-notities/builds/latest/output.pdf][https://www.sharelatex.com/github/repos/NorfairKing/ab-notities/builds/latest/badge.svg]]
 
 ** Externe links
 


### PR DESCRIPTION
Quite annoying because people tend to click on badges...
