### PR TITLE
fix: NFA naar regexp

### DIFF
--- a/eindige-automaten.tex
+++ b/eindige-automaten.tex
@@ -449,7 +449,7 @@ Vanaf deze sectie gaan we ervan uit dat een NFA hoogstens \'e\'en aanvaardbare e
   \begin{proof}
     Beschouw de vier bewerkingen in de algebra van reguliere expressies: unie $\cup_{R}$, concatenatie $\cdot_{R}$, complement $^{c}_{R}$ en doorsnede $\cap_{R}$.
     Er bestaan overeenkomstige bewerkingen in de algebra van NFA's: unie $\cup_{N}$, concatenatie $\cdot_{N}$, complement $^{c}_{R}$ en doorsnede $\cap_{N}$.
-    Bovendien bestaat er een functie die een willekeurige reguliere expressie afbeeldt op een reguliere expressie die dezelfde taal bepaalt en omgekeerd.\stref{st:nfa-naar-regex} \stref{st:regex-naar-NFA}
+    Bovendien bestaat er een functie die een willekeurige NFA afbeeldt op een reguliere expressie die dezelfde taal bepaalt en omgekeerd.\stref{st:nfa-naar-regex} \stref{st:regex-naar-NFA}
     Er bestaat dus een eenvoudig isomorfisme tussen deze twee algebra's.
   \end{proof}
 \end{ei}


### PR DESCRIPTION
Er stond dat er een functie bestaat "die een _reguliere expressie_ afbeeldt op een _reguliere expressie_".
Dat is uiteraard triviaal (identiteitsfunctie), maar in dit geval gaat het over NFA naar reguliere expressie en omgekeerd.

Duidelijk een fout bij het uittypen van dit bewijs. Het is nu gecorrigeerd.